### PR TITLE
Added support for the UDP6 transport

### DIFF
--- a/check_synology_cpu.py
+++ b/check_synology_cpu.py
@@ -16,7 +16,7 @@
 import sys
 from argparse import ArgumentParser
 from pysnmp.hlapi import bulkCmd, SnmpEngine, UsmUserData, \
-                         UdpTransportTarget, \
+                         UdpTransportTarget, Udp6TransportTarget, \
                          ObjectType, ObjectIdentity, \
                          ContextData, usmHMACMD5AuthProtocol, \
                          usmHMACSHAAuthProtocol, \
@@ -56,6 +56,8 @@ def get_args():
                           type=int, dest='port', default=161)
     connopts.add_argument("-t", "--timeout", required=False, help="SNMP timeout",
                           type=int, dest='timeout', default=10)
+    connopts.add_argument("-6", "--ipv6", required=False, help='Use IPv6',
+                          dest='ipv6', action='store_true', default=False)
     thresholds = parser.add_argument_group('Thresholds')
     thresholds.add_argument("-w", "--warn", required=False,
                             help="Memory warning threshold (in percent)",
@@ -93,13 +95,18 @@ def get_snmp_table(table_oid, args):
     # initialize empty list for return object
     table = []
 
+    if args.ipv6:
+        transport_target = Udp6TransportTarget((args.host, args.port), timeout=args.timeout)
+    else:
+        transport_target = UdpTransportTarget((args.host, args.port), timeout=args.timeout)
+
     if args.v3mode == "authPriv":
         iterator = bulkCmd(
             SnmpEngine(),
             UsmUserData(args.user, args.authkey, args.privkey,
                         authProtocol=authprot[args.authmode],
                         privProtocol=privprot[args.privmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 20,
             ObjectType(ObjectIdentity(table_oid)),
@@ -111,7 +118,7 @@ def get_snmp_table(table_oid, args):
             SnmpEngine(),
             UsmUserData(args.user, args.authkey,
                         authProtocol=authprot[args.authmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 20,
             ObjectType(ObjectIdentity(table_oid)),

--- a/check_synology_disks.py
+++ b/check_synology_disks.py
@@ -18,7 +18,7 @@ import sys
 from argparse import ArgumentParser
 from itertools import chain
 from pysnmp.hlapi import bulkCmd, SnmpEngine, UsmUserData, \
-                         UdpTransportTarget, \
+                         UdpTransportTarget, Udp6TransportTarget, \
                          ObjectType, ObjectIdentity, \
                          ContextData, usmHMACMD5AuthProtocol, \
                          usmHMACSHAAuthProtocol, \
@@ -70,6 +70,8 @@ def get_args():
     connopts.add_argument("-t", "--timeout", required=False,
                           help="SNMP timeout", type=int, dest='timeout',
                           default=10)
+    connopts.add_argument("-6", "--ipv6", required=False, help='Use IPv6',
+                          dest='ipv6', action='store_true', default=False)
     snmpopts = parser.add_argument_group('SNMPv3 parameters')
     snmpopts.add_argument("-u", "--user", required=True, help="SNMPv3 user name",
                           type=str, dest='user')
@@ -101,13 +103,18 @@ def get_snmp_table(table_oid, args):
     # initialize empty list for return object
     table = []
 
+    if args.ipv6:
+        transport_target = Udp6TransportTarget((args.host, args.port), timeout=args.timeout)
+    else:
+        transport_target = UdpTransportTarget((args.host, args.port), timeout=args.timeout)
+
     if args.v3mode == "authPriv":
         iterator = bulkCmd(
             SnmpEngine(),
             UsmUserData(args.user, args.authkey, args.privkey,
                         authProtocol=authprot[args.authmode],
                         privProtocol=privprot[args.privmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 50,
             ObjectType(ObjectIdentity(table_oid)),
@@ -119,7 +126,7 @@ def get_snmp_table(table_oid, args):
             SnmpEngine(),
             UsmUserData(args.user, args.authkey,
                         authProtocol=authprot[args.authmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 50,
             ObjectType(ObjectIdentity(table_oid)),

--- a/check_synology_ups.py
+++ b/check_synology_ups.py
@@ -17,7 +17,7 @@
 import sys
 from argparse import ArgumentParser
 from pysnmp.hlapi import bulkCmd, SnmpEngine, UsmUserData, \
-                         UdpTransportTarget, \
+                         UdpTransportTarget, Udp6TransportTarget, \
                          ObjectType, ObjectIdentity, \
                          ContextData, usmHMACMD5AuthProtocol, \
                          usmHMACSHAAuthProtocol, \
@@ -57,6 +57,8 @@ def get_args():
                           type=int, dest='port', default=161)
     connopts.add_argument("-t", "--timeout", required=False, help="SNMP timeout",
                           type=int, dest='timeout', default=10)
+    connopts.add_argument("-6", "--ipv6", required=False, help='Use IPv6',
+                          dest='ipv6', action='store_true', default=False)
     snmpopts = parser.add_argument_group('SNMPv3 parameters')
     snmpopts.add_argument("-u", "--user", required=True,
                           help="SNMPv3 user name", type=str, dest='user')
@@ -87,13 +89,18 @@ def get_snmp_table(table_oid, args):
     # initialize empty list for return object
     table = []
 
+    if args.ipv6:
+        transport_target = Udp6TransportTarget((args.host, args.port), timeout=args.timeout)
+    else:
+        transport_target = UdpTransportTarget((args.host, args.port), timeout=args.timeout)
+
     if args.v3mode == "authPriv":
         iterator = bulkCmd(
             SnmpEngine(),
             UsmUserData(args.user, args.authkey, args.privkey,
                         authProtocol=authprot[args.authmode],
                         privProtocol=privprot[args.privmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 20,
             ObjectType(ObjectIdentity(table_oid)),
@@ -105,7 +112,7 @@ def get_snmp_table(table_oid, args):
             SnmpEngine(),
             UsmUserData(args.user, args.authkey,
                         authProtocol=authprot[args.authmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 20,
             ObjectType(ObjectIdentity(table_oid)),

--- a/check_synology_volumes.py
+++ b/check_synology_volumes.py
@@ -19,7 +19,7 @@ from re import match
 from argparse import ArgumentParser
 from itertools import chain
 from pysnmp.hlapi import bulkCmd, SnmpEngine, UsmUserData, \
-                         UdpTransportTarget, \
+                         UdpTransportTarget, Udp6TransportTarget, \
                          ObjectType, ObjectIdentity, \
                          ContextData, usmHMACMD5AuthProtocol, \
                          usmHMACSHAAuthProtocol, \
@@ -87,6 +87,8 @@ def get_args():
                           type=int, dest='port', default=161)
     connopts.add_argument("-t", "--timeout", required=False, help="SNMP timeout",
                           type=int, dest='timeout', default=10)
+    connopts.add_argument("-6", "--ipv6", required=False, help='Use IPv6',
+                          dest='ipv6', action='store_true', default=False)
     thresholds = parser.add_argument_group('Thresholds')
     thresholds.add_argument("-w", "--warn", required=False,
                             help="Volume warning threshold (in percent)",
@@ -124,13 +126,18 @@ def get_snmp_table(table_oid, args):
     # initialize empty list for return object
     table = []
 
+    if args.ipv6:
+        transport_target = Udp6TransportTarget((args.host, args.port), timeout=args.timeout)
+    else:
+        transport_target = UdpTransportTarget((args.host, args.port), timeout=args.timeout)
+
     if args.v3mode == "authPriv":
         iterator = bulkCmd(
             SnmpEngine(),
             UsmUserData(args.user, args.authkey, args.privkey,
                         authProtocol=authprot[args.authmode],
                         privProtocol=privprot[args.privmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 50,
             ObjectType(ObjectIdentity(table_oid)),
@@ -142,7 +149,7 @@ def get_snmp_table(table_oid, args):
             SnmpEngine(),
             UsmUserData(args.user, args.authkey,
                         authProtocol=authprot[args.authmode]),
-            UdpTransportTarget((args.host, args.port), timeout=args.timeout),
+            transport_target,
             ContextData(),
             0, 50,
             ObjectType(ObjectIdentity(table_oid)),


### PR DESCRIPTION
This PR adds support for IPv6.

This is actually a very simple change, I just added a new boolean option `--ipv6` (short `-6`) and use an instance of `Udp6TransportTarget` or `UdpTransportTarget` depending on whether it is set or not.